### PR TITLE
Return single response

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -19,7 +19,7 @@ lint:
   enabled:
     - bandit@1.7.8
     - black@24.4.2
-    - checkov@3.2.124
+    - checkov@3.2.125
     - dotenv-linter@3.3.0
     - git-diff-check
     - isort@5.13.2

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ install:
 	@python -m textblob.download_corpora
 ifeq ($(TRUNK_INSTALLED), 0)
 	@curl https://get.trunk.io -fsSL | bash -s -- -y
-	@trunk init
 endif
 
 trunk:

--- a/npcs/main.py
+++ b/npcs/main.py
@@ -10,7 +10,7 @@ SEED_MEMORIES = [
     ),
     NPCMemory(
         npc="Jimmy Buffett",
-        memory="This inn's name is Margaritaville.",
+        memory="The name of this inn is Margaritaville.",
         entities={"Margaritaville"},
     ),
     NPCMemory(

--- a/npcs/main.py
+++ b/npcs/main.py
@@ -16,12 +16,12 @@ SEED_MEMORIES = [
     NPCMemory(
         npc="Jimmy Buffett",
         memory="The inn is in Havana.",
-        entities={"Margaritaville"},
+        entities={"Margaritaville", "Havana"},
     ),
     NPCMemory(
         npc="Jimmy Buffett",
-        memory="A margarita costs 4 copper pieces at Margaritaville.",
-        entities={"margarita", "Margaritaville"},
+        memory="It costs 1 silver piece to stay the night at Margaritaville.",
+        entities={"Margaritaville"},
     ),
 ]
 

--- a/npcs/main.py
+++ b/npcs/main.py
@@ -5,23 +5,23 @@ NPC_NAME = "Jimmy Buffett"
 SEED_MEMORIES = [
     NPCMemory(
         npc="Jimmy Buffett",
-        memory="A mug of ale costs 4 copper pieces.",
-        entities={"ale"},
+        memory="A margarita costs 4 copper pieces.",
+        entities={"margarita"},
     ),
     NPCMemory(
         npc="Jimmy Buffett",
-        memory="This inn's name is the Silver Fox.",
-        entities={"Silver Fox"},
+        memory="This inn's name is Margaritaville.",
+        entities={"Margaritaville"},
     ),
     NPCMemory(
         npc="Jimmy Buffett",
-        memory="It costs 1 silver piece a night to stay at the inn.",
-        entities={"Silver Fox"},
+        memory="The inn is in Havana.",
+        entities={"Margaritaville"},
     ),
     NPCMemory(
         npc="Jimmy Buffett",
-        memory="A mug of ale costs 4 copper pieces at the Silver Fox.",
-        entities={"ale", "Silver Fox"},
+        memory="A margarita costs 4 copper pieces at Margaritaville.",
+        entities={"margarita", "Margaritaville"},
     ),
 ]
 
@@ -31,8 +31,8 @@ def run():
         convo = Conversation(name=NPC_NAME, index=idx)
 
         while True:
-            message = input("Prompt: ")
-            print(convo.say(message))
+            message = input("> ")
+            print(convo.say(message.lstrip("> ")))
 
 
 if __name__ == "__main__":

--- a/npcs/memory/conversation.py
+++ b/npcs/memory/conversation.py
@@ -41,6 +41,7 @@ chat_prompt = tokenizer.apply_chat_template(
     messages, tokenize=False, add_generation_prompt=True, return_tensors="pt"
 )
 # append character name to assistant generation prompt
+# otherwise the model will prepend this to the response
 template = chat_prompt + "{name}:"
 
 

--- a/npcs/memory/conversation.py
+++ b/npcs/memory/conversation.py
@@ -1,6 +1,5 @@
 from langchain.chains.conversation.base import ConversationChain
 from langchain.prompts import (
-    AIMessagePromptTemplate,
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
     SystemMessagePromptTemplate,

--- a/npcs/memory/conversation.py
+++ b/npcs/memory/conversation.py
@@ -21,17 +21,16 @@ from .search import NPCMemoryVectorStore
 # about the character
 messages = [
     SystemMessagePromptTemplate.from_template(
-        """Reply to the input from the Player below as though you are an NPC.
-The NPC will provide the Player with contextual information.
-The NPC ONLY uses information contained in the "Relevant Information" section and does not hallucinate.
+        """Reply to the input as though you are {name}.
+Only use information contained in the "Relevant Information" section.
+Then, wait for the next input.
 
 Relevant Information:
 
 {history}
 """
     ),
-    HumanMessagePromptTemplate.from_template("Player: {input}"),
-    AIMessagePromptTemplate.from_template("NPC: "),
+    HumanMessagePromptTemplate.from_template("{input}"),
 ]
 
 

--- a/npcs/memory/index.py
+++ b/npcs/memory/index.py
@@ -14,11 +14,12 @@ from .search import NPCMemoryVectorStore
 class IndexedMemory(BaseMemory, BaseModel):
     name: str
     index: NPCMemoryVectorStore
+    name_key: str = "name"
     memory_key: str = "history"
 
     @property
     def memory_variables(self) -> List[str]:
-        return [self.memory_key]
+        return [self.name_key, self.memory_key]
 
     def load_memory_variables(self, inputs: Dict[str, str]) -> Dict[str, str]:
         print("Loading memories: ", inputs)
@@ -26,7 +27,7 @@ class IndexedMemory(BaseMemory, BaseModel):
         # pipeline when saving memories; can we avoid running it both times?
         search = f'npc:"{self.name}"'
         memories = "\n".join([mem.memory for mem in self.index.search_memories(search)])
-        return {self.memory_key: memories}
+        return {self.name_key: self.name, self.memory_key: memories}
 
     def save_context(self, inputs: Dict[str, str], outputs: Dict[str, str]) -> None:
         print("Saving memories: ", inputs, outputs)


### PR DESCRIPTION
Previously, the HF Zephyr model was returning an entire dialogue when prompted. With some tweaks, it should now return only a single response to the last user message.

* Use the `transformers` tokenizer to generate a prompt template appropriate for the HF model
* Add name key to `IndexMemory` to include in conversation chain inputs
* Experiment with character seeded prompts